### PR TITLE
Add redirects from fcct to butane

### DIFF
--- a/fcct/config-fcos-v1_0/index.html
+++ b/fcct/config-fcos-v1_0/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/config-fcos-v1_0/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/config-fcos-v1_0/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/config-fcos-v1_0/'>coreos.github.io/butane/config-fcos-v1_0/</a>.
+  </body>
+</html>

--- a/fcct/config-fcos-v1_1/index.html
+++ b/fcct/config-fcos-v1_1/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/config-fcos-v1_1/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/config-fcos-v1_1/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/config-fcos-v1_1/'>coreos.github.io/butane/config-fcos-v1_1/</a>.
+  </body>
+</html>

--- a/fcct/config-fcos-v1_2/index.html
+++ b/fcct/config-fcos-v1_2/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/config-fcos-v1_2/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/config-fcos-v1_2/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/config-fcos-v1_2/'>coreos.github.io/butane/config-fcos-v1_2/</a>.
+  </body>
+</html>

--- a/fcct/config-fcos-v1_3/index.html
+++ b/fcct/config-fcos-v1_3/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/config-fcos-v1_3/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/config-fcos-v1_3/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/config-fcos-v1_3/'>coreos.github.io/butane/config-fcos-v1_3/</a>.
+  </body>
+</html>

--- a/fcct/config-fcos-v1_4-exp/index.html
+++ b/fcct/config-fcos-v1_4-exp/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/specs/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/specs/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/specs/'>coreos.github.io/butane/specs/</a>.
+  </body>
+</html>

--- a/fcct/config-openshift-v4_8-exp/index.html
+++ b/fcct/config-openshift-v4_8-exp/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/config-openshift-v4_8/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/config-openshift-v4_8/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/config-openshift-v4_8/'>coreos.github.io/butane/config-openshift-v4_8/</a>.
+  </body>
+</html>

--- a/fcct/config-rhcos-v0_1/index.html
+++ b/fcct/config-rhcos-v0_1/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/config-rhcos-v0_1/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/config-rhcos-v0_1/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/config-rhcos-v0_1/'>coreos.github.io/butane/config-rhcos-v0_1/</a>.
+  </body>
+</html>

--- a/fcct/development/index.html
+++ b/fcct/development/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/development/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/development/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/development/'>coreos.github.io/butane/development/</a>.
+  </body>
+</html>

--- a/fcct/examples/index.html
+++ b/fcct/examples/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/examples/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/examples/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/examples/'>coreos.github.io/butane/examples/</a>.
+  </body>
+</html>

--- a/fcct/getting-started/index.html
+++ b/fcct/getting-started/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/getting-started/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/getting-started/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/getting-started/'>coreos.github.io/butane/getting-started/</a>.
+  </body>
+</html>

--- a/fcct/index.html
+++ b/fcct/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/'>coreos.github.io/butane/</a>.
+  </body>
+</html>

--- a/fcct/migrating-configs/index.html
+++ b/fcct/migrating-configs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/migrating-configs/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/migrating-configs/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/migrating-configs/'>coreos.github.io/butane/migrating-configs/</a>.
+  </body>
+</html>

--- a/fcct/specs/index.html
+++ b/fcct/specs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/specs/">
+    <script type="text/javascript">
+      window.location.href = "https://coreos.github.io/butane/specs/"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/specs/'>coreos.github.io/butane/specs/</a>.
+  </body>
+</html>


### PR DESCRIPTION
Renaming a repository [does not add redirects](https://docs.github.com/en/github/administering-a-repository/renaming-a-repository) for the corresponding GitHub Pages site.  Maintain the redirects ourselves.

For https://github.com/coreos/fcct/issues/167.