### PR TITLE
fcct: update redirect to migration guide

### DIFF
--- a/fcct/migrating-configs/index.html
+++ b/fcct/migrating-configs/index.html
@@ -2,13 +2,13 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/migrating-configs/">
+    <meta http-equiv="refresh" content="0; url=https://coreos.github.io/butane/upgrading/">
     <script type="text/javascript">
-      window.location.href = "https://coreos.github.io/butane/migrating-configs/"
+      window.location.href = "https://coreos.github.io/butane/upgrading/"
     </script>
     <title>Page Redirection</title>
   </head>
   <body>
-    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/migrating-configs/'>coreos.github.io/butane/migrating-configs/</a>.
+    If you are not redirected automatically, please go to <a href='https://coreos.github.io/butane/upgrading/'>coreos.github.io/butane/upgrading/</a>.
   </body>
 </html>


### PR DESCRIPTION
Part of https://github.com/coreos/butane/pull/227.